### PR TITLE
Add Toggles to Hide Buttons/Disable Interaction for Inline Clocks

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
 	"id": "progress-clocks",
 	"name": "Progress Clocks",
-	"version": "0.3.1",
+	"version": "0.3.2",
 	"minAppVersion": "0.12.0",
 	"description": "Progress clocks and other useful widgets for real-time status tracking.",
 	"author": "Nathan Clark",

--- a/src/ProgressClocksPlugin.ts
+++ b/src/ProgressClocksPlugin.ts
@@ -5,9 +5,25 @@ import ProgressClocksView, { VIEW_TYPE } from './ProgressClocksView'
 import { inlinePlugin, parseCode } from './inline/InlinePlugin'
 import Clock from './ui/Clock.svelte'
 import Counter from './ui/Counter.svelte'
+import { ProgressClocksSettingsTab } from './ProgressClocksSettingsTab'
+
+interface ProgressClocksPluginSettings {
+  showButtonsForInlineClocks: boolean;
+  allowClickInteractionForInlineClocks: boolean;
+}
+
+const DEFAULT_SETTINGS: Partial<ProgressClocksPluginSettings> = {
+  showButtonsForInlineClocks: true,
+  allowClickInteractionForInlineClocks: true
+};
 
 export default class ProgressClocksPlugin extends Plugin {
+  settings: ProgressClocksPluginSettings;
+
   async onload () {
+    await this.loadSettings();
+    this.addSettingTab(new ProgressClocksSettingsTab(this.app, this));
+
     this.registerView(
       VIEW_TYPE,
       (leaf: WorkspaceLeaf) => new ProgressClocksView(this, leaf))
@@ -28,6 +44,14 @@ export default class ProgressClocksPlugin extends Plugin {
     this.registerEditorExtension(inlinePlugin(this))
 
     this.registerMarkdownPostProcessor(this.handleMarkdownPostProcessor.bind(this))
+  }
+
+  async loadSettings() {
+    this.settings = Object.assign({}, DEFAULT_SETTINGS, await this.loadData());
+  }
+
+  async saveSettings() {
+    await this.saveData(this.settings);
   }
 
   async addView () {
@@ -62,7 +86,9 @@ export default class ProgressClocksPlugin extends Plugin {
             target: container,
             props: {
               segments,
-              filled
+              filled,
+              showButtonsForInlineClocks: this.settings.showButtonsForInlineClocks,
+              allowClickInteractionForInlineClocks: this.settings.allowClickInteractionForInlineClocks
             }
           })
 

--- a/src/ProgressClocksSettingsTab.ts
+++ b/src/ProgressClocksSettingsTab.ts
@@ -1,0 +1,43 @@
+import ProgressClocksPlugin from "./ProgressClocksPlugin";
+import { App, PluginSettingTab, Setting } from "obsidian";
+
+export class ProgressClocksSettingsTab extends PluginSettingTab {
+  plugin: ProgressClocksPlugin;
+
+  constructor(app: App, plugin: ProgressClocksPlugin) {
+    super(app, plugin);
+    this.plugin = plugin;
+  }
+
+  display(): void {
+    const { containerEl } = this;
+
+    containerEl.empty();
+
+    new Setting(containerEl)
+      .setName("Show Buttons for Inline Clocks")
+      .setDesc("When turned on, inline clocks will render with buttons to increment/decrement the clock, and " +
+        "add/remove segments from the clock. When turned off, inline clocks will render without any buttons.")
+      .addToggle((toggle) =>
+        toggle
+          .setValue(this.plugin.settings.showButtonsForInlineClocks)
+          .onChange(async (value) => {
+            this.plugin.settings.showButtonsForInlineClocks = value;
+            await this.plugin.saveSettings();
+          })
+      );
+    
+    new Setting(containerEl)
+      .setName("Allow Click Interaction for Inline Clocks")
+      .setDesc("When turned on, inline clocks will respond to mouse clicks by adjusting the value of the " +
+        "clock. When turned off, the only way to update inline clocks is to edit the inline code block.")
+      .addToggle((toggle) => 
+        toggle
+          .setValue(this.plugin.settings.allowClickInteractionForInlineClocks)
+          .onChange(async (value) => {
+            this.plugin.settings.allowClickInteractionForInlineClocks = value;
+            await this.plugin.saveSettings();
+          })
+      );
+  }
+}

--- a/src/inline/ClockWidget.ts
+++ b/src/inline/ClockWidget.ts
@@ -1,8 +1,8 @@
-import { 
+import {
   EditorView,
   WidgetType
 } from '@codemirror/view'
-  
+
 import Clock from '../ui/Clock.svelte'
 
 type UpdateEvent = {
@@ -17,19 +17,23 @@ export default class ClockWidget extends WidgetType {
     readonly segments: number = 4,
     readonly filled: number = 0,
     readonly nodeFrom: number,
-    readonly nodeTo: number) {
+    readonly nodeTo: number,
+    readonly showButtonsForInlineClocks: boolean,
+    readonly allowClickInteractionForInlineClocks: boolean) {
     super()
   }
 
   toDOM (view: EditorView): HTMLElement {
     const container = document.createElement('div')
     container.addClass('progress-clocks-inline')
-    
+
     const clock = new Clock({
       target: container,
       props: {
         segments: this.segments,
-        filled: this.filled
+        filled: this.filled,
+        showButtonsForInlineClocks: this.showButtonsForInlineClocks,
+        allowClickInteractionForInlineClocks: this.allowClickInteractionForInlineClocks
       }
     })
 

--- a/src/ui/Clock.svelte
+++ b/src/ui/Clock.svelte
@@ -5,6 +5,8 @@ import { ifClickEquivalent } from './util'
 
 export let segments: number = 4
 export let filled: number = 0
+export let showButtonsForInlineClocks: boolean = true;
+export let allowClickInteractionForInlineClocks: boolean = true;
 
 const dispatch = createEventDispatcher()
 
@@ -41,6 +43,7 @@ function slices(segments: number, filled: number) {
 }
 
 function handleIncrement(e: MouseEvent | KeyboardEvent) {
+  if (!allowClickInteractionForInlineClocks) return;
   if (e.ctrlKey || e.metaKey) {
     segments += 1
   } else {
@@ -49,6 +52,7 @@ function handleIncrement(e: MouseEvent | KeyboardEvent) {
 }
 
 function handleDecrement(e: MouseEvent | KeyboardEvent) {
+  if (!allowClickInteractionForInlineClocks) return;
   if (e.ctrlKey || e.metaKey) {
     segments -= 1
     filled = Math.min(segments, filled)
@@ -58,6 +62,7 @@ function handleDecrement(e: MouseEvent | KeyboardEvent) {
 }
 
 function handleClockKeyInteraction(e: KeyboardEvent) {
+  if (!allowClickInteractionForInlineClocks) return;
   if (['Enter', ' ', 'ArrowUp', 'ArrowRight'].contains(e.key)) {
     if (e.ctrlKey || e.metaKey) {
       segments += 1
@@ -104,34 +109,36 @@ function handleClockKeyInteraction(e: KeyboardEvent) {
     {/if}
     <circle cx={radius + padding} cy={radius + padding} r={radius} data-filled={fillCircle} />
   </svg>
-  <div class="progress-clocks-clock__buttons">
-    <button
-      class="progress-clocks-clock__decrement"
-      title="Unfill one segment"
-      on:click|preventDefault={handleDecrement}
-      on:keydown={ifClickEquivalent(handleDecrement)}>
-      <MinusSquare />
-    </button>
-    <button
-      class="progress-clocks-clock__increment"
-      title="Fill one segment"
-      on:click|preventDefault={handleIncrement}
-      on:keydown={ifClickEquivalent(handleIncrement)}>
-      <PlusSquare />
-    </button>
-    <button
-      class="progress-clocks-clock__decrement-segments"
-      title="Remove one segment"
-      on:click|preventDefault={() => (segments -= 1)}
-      on:keydown={ifClickEquivalent(() => (segments -= 1))}>
-      <ArrowDownFromLine />
-    </button>
-    <button
-      class="progress-clocks-clock__increment-segments"
-      title="Add another segment"
-      on:click|preventDefault={() => (segments += 1)}
-      on:keydown={ifClickEquivalent(() => (segments += 1))}>
-      <ArrowUpFromLine />
-    </button>
-  </div>
+  {#if showButtonsForInlineClocks}
+    <div class="progress-clocks-clock__buttons">
+      <button
+        class="progress-clocks-clock__decrement"
+        title="Unfill one segment"
+        on:click|preventDefault={handleDecrement}
+        on:keydown={ifClickEquivalent(handleDecrement)}>
+        <MinusSquare />
+      </button>
+      <button
+        class="progress-clocks-clock__increment"
+        title="Fill one segment"
+        on:click|preventDefault={handleIncrement}
+        on:keydown={ifClickEquivalent(handleIncrement)}>
+        <PlusSquare />
+      </button>
+      <button
+        class="progress-clocks-clock__decrement-segments"
+        title="Remove one segment"
+        on:click|preventDefault={() => (segments -= 1)}
+        on:keydown={ifClickEquivalent(() => (segments -= 1))}>
+        <ArrowDownFromLine />
+      </button>
+      <button
+        class="progress-clocks-clock__increment-segments"
+        title="Add another segment"
+        on:click|preventDefault={() => (segments += 1)}
+        on:keydown={ifClickEquivalent(() => (segments += 1))}>
+        <ArrowUpFromLine />
+      </button>
+    </div>
+  {/if}
 </div>


### PR DESCRIPTION
The changes here are relatively straightforward.  There's a new `ProgressClocksSettingsTab.ts` file that specifies what options should be shown in the plugin's settings page, and some boilerplate in `ProgressClocksPlugin.ts` to set it up, save the settings, and pass them to the `Clock` object in the `handleMarkdownPostProcessor` function.

The `ClockWidget` and `InlinePlugin` were adjusted to pass the settings values through to `Clock.svelte`, which has a few changes to conditionally disable click interactions or hide the buttons, depending on the settings.

Closes #9 